### PR TITLE
fix(splio-sdk): fix usage with new Lazy Ghost Object in Symfony 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "PHP wrapper for Splio CRM and router",
   "type": "library",
   "require": {
+    "php": ">=7.4.0",
     "ext-ftp": "*",
     "ext-json": "*",
     "psr/http-client-implementation": "^1.0",

--- a/src/SplioSdk.php
+++ b/src/SplioSdk.php
@@ -17,8 +17,11 @@ use Splio\Service\Service;
 
 class SplioSdk
 {
-    protected $config;
-    protected $services;
+    protected array $config;
+    protected ?Service $service = null;
+    private ClientInterface $httpClient;
+    private RequestFactoryInterface $requestFactory;
+    private StreamFactoryInterface $streamFactory;
 
     /**
      * Setting up Splio configuration.
@@ -47,24 +50,12 @@ class SplioSdk
      *                      )
      * }
      */
-    public function __construct($config = [], ?ClientInterface $httpClient = null, ?RequestFactoryInterface $requestFactory = null, ?StreamFactoryInterface $streamFactory = null)
+    public function __construct(array $config = [], ?ClientInterface $httpClient = null, ?RequestFactoryInterface $requestFactory = null, ?StreamFactoryInterface $streamFactory = null)
     {
         $this->config = $config;
-        $this->initServices(
-            $httpClient ?: HttpClientDiscovery::find(),
-            $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory(),
-            $streamFactory ?: Psr17FactoryDiscovery::findStreamFactory()
-        );
-    }
-
-    /**
-     * Initialize services.
-     */
-    protected function initServices(ClientInterface $httpClient, RequestFactoryInterface $requestFactoryInterface, StreamFactoryInterface $streamFactory)
-    {
-        $service = new Service($this->config, $httpClient, $requestFactoryInterface, $streamFactory);
-
-        $this->service = $service;
+        $this->httpClient = $httpClient ?: HttpClientDiscovery::find();
+        $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
+        $this->streamFactory = $streamFactory ?: Psr17FactoryDiscovery::findStreamFactory();
     }
 
     /**
@@ -84,6 +75,6 @@ class SplioSdk
      */
     public function getService(): Service
     {
-        return $this->service;
+        return $this->service ??= new Service($this->config, $this->httpClient, $this->requestFactory, $this->streamFactory);
     }
 }


### PR DESCRIPTION
Afin de corriger cette erreur sur notre application Wamiz : 
![image](https://user-images.githubusercontent.com/2103975/228191185-8223407e-eb63-41cb-83c9-0a70505039d7.png)

En local : 
![image](https://user-images.githubusercontent.com/2103975/228191325-520b80da-e625-4dee-b6b0-a41b1cc74ecf.png)

C'est dû au fait que ce service est enregistrée de manière lazy dans notre application, et que `initServices()` ne semble pas appelée (ou alors elle est appelée, mais ne modifie pas la propriété `service` du ghost object / object original).

- https://symfony.com/doc/current/service_container/lazy_services.html